### PR TITLE
Update boostrapping header with Absyn.Exp.BREAK

### DIFF
--- a/tarball-include/OpenModelicaBootstrappingHeader.h
+++ b/tarball-include/OpenModelicaBootstrappingHeader.h
@@ -1821,7 +1821,7 @@ extern struct record_description Absyn_Within_WITHIN__desc;
 #ifdef ADD_METARECORD_DEFINITIONS
 #ifndef Absyn_Class_CLASS__desc_added
 #define Absyn_Class_CLASS__desc_added
-ADD_METARECORD_DEFINITIONS const char* Absyn_Class_CLASS__desc__fields[9] = {"name","partialPrefix","finalPrefix","encapsulatedPrefix","restriction","body","commentsBeforeEnd","commentsAfterEnd","info"};
+ADD_METARECORD_DEFINITIONS const char* Absyn_Class_CLASS__desc__fields[7] = {"name","partialPrefix","finalPrefix","encapsulatedPrefix","restriction","body","info"};
 ADD_METARECORD_DEFINITIONS struct record_description Absyn_Class_CLASS__desc = {
   "Absyn_Class_CLASS",
   "Absyn.Class.CLASS",
@@ -1831,8 +1831,8 @@ ADD_METARECORD_DEFINITIONS struct record_description Absyn_Class_CLASS__desc = {
 #else /* Only use the file as a header */
 extern struct record_description Absyn_Class_CLASS__desc;
 #endif
-#define Absyn__CLASS_3dBOX9 3
-#define Absyn__CLASS(name,partialPrefix,finalPrefix,encapsulatedPrefix,restriction,body,commentsBeforeEnd,commentsAfterEnd,info) (mmc_mk_box(10, 3,&Absyn_Class_CLASS__desc,name,partialPrefix,finalPrefix,encapsulatedPrefix,restriction,body,commentsBeforeEnd,commentsAfterEnd,info))
+#define Absyn__CLASS_3dBOX7 3
+#define Absyn__CLASS(name,partialPrefix,finalPrefix,encapsulatedPrefix,restriction,body,info) (mmc_mk_box8(3,&Absyn_Class_CLASS__desc,name,partialPrefix,finalPrefix,encapsulatedPrefix,restriction,body,info))
 #ifdef ADD_METARECORD_DEFINITIONS
 #ifndef Absyn_ClassDef_PDER__desc_added
 #define Absyn_ClassDef_PDER__desc_added
@@ -3258,6 +3258,22 @@ extern struct record_description Absyn_Direction_INPUT__desc;
 #define Absyn__INPUT_3dBOX0 3
 static const MMC_DEFSTRUCTLIT(Absyn__INPUT__struct,1,3) {&Absyn_Direction_INPUT__desc}};
 static void *Absyn__INPUT = MMC_REFSTRUCTLIT(Absyn__INPUT__struct);
+#ifdef ADD_METARECORD_DEFINITIONS
+#ifndef Absyn_Exp_BREAK__desc_added
+#define Absyn_Exp_BREAK__desc_added
+ADD_METARECORD_DEFINITIONS const char* Absyn_Exp_BREAK__desc__fields[1] = {"no fields"};
+ADD_METARECORD_DEFINITIONS struct record_description Absyn_Exp_BREAK__desc = {
+  "Absyn_Exp_BREAK",
+  "Absyn.Exp.BREAK",
+  Absyn_Exp_BREAK__desc__fields
+};
+#endif
+#else /* Only use the file as a header */
+extern struct record_description Absyn_Exp_BREAK__desc;
+#endif
+#define Absyn__BREAK_3dBOX0 29
+static const MMC_DEFSTRUCTLIT(Absyn__BREAK__struct,1,29) {&Absyn_Exp_BREAK__desc}};
+static void *Absyn__BREAK = MMC_REFSTRUCTLIT(Absyn__BREAK__struct);
 #ifdef ADD_METARECORD_DEFINITIONS
 #ifndef Absyn_Exp_SUBSCRIPTED__EXP__desc_added
 #define Absyn_Exp_SUBSCRIPTED__EXP__desc_added


### PR DESCRIPTION
- Add Absyn.Exp.BREAK to bootstrapping header.
- Revert change to Absyn.Class.CLASS to keep it in sync with the non-cmake build.