### PR TITLE
Replacing removed macro EXIT with exit.

### DIFF
--- a/bootstrap-sources/build/_main.c
+++ b/bootstrap-sources/build/_main.c
@@ -54,7 +54,6 @@ MMC_CATCH_TOP(return rml_execution_failed());
 }
 }
 fflush(NULL);
-EXIT(0);
 return 0;
 }
 #endif


### PR DESCRIPTION
Needed for https://github.com/OpenModelica/OpenModelica/pull/12580.